### PR TITLE
OSx Big Sur and Firefox 88 Compatibility Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,6 @@
 
 Make Firefox look native on macOS.
 
-Updated package from https://github.com/diedummydie/Safari-Theme-for-Firefox, compatible with OSx Big Sur and Firefox 88. Errors that have been resolved in this first release:
-
-- Fix empty back and forward buttons (fix from @gamunu, https://github.com/diedummydie/Safari-Theme-for-Firefox/pull/19)
-- Location minimize/maximize/close buttons on OSx restored
-- Removed borders, thick lightblue border when activated
-- Resolved issue of moving text while hovering over tabs
-- ...
-
-Example of this update:
-
-<img width="462" alt="Screenshot 2021-05-14 at 22 21 13" src="https://user-images.githubusercontent.com/12695083/118324751-f8401780-b4f1-11eb-906f-cc120353ba58.png">
-<img width="478" alt="Screenshot 2021-05-14 at 22 22 05" src="https://user-images.githubusercontent.com/12695083/118324817-13ab2280-b4f2-11eb-8475-87b4317e89b5.png">
-
-
 Switch between Light Mode and Dark Mode without editing CSS.
 
 ![screenshot](https://raw.githubusercontent.com/diedummydie/Safari-Theme-for-Firefox/master/etc/screenshot.jpg)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Safari Theme for Firefox
 
-Make Firefox look more native on macOS.
+Make Firefox look native on macOS.
 
 Updated package from https://github.com/diedummydie/Safari-Theme-for-Firefox, compatible with OSx Big Sur and Firefox 88. Errors that have been resolved in this first release:
 

--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ Switch between Light Mode and Dark Mode without editing CSS.
 
 ### Acknowledgements
 
-Made possible with advice and code examples contributed by the community of [reddit.com/r/FirefoxCSS](https://www.reddit.com/r/FirefoxCSS/), [support.mozilla.org](https://support.mozilla.org/en-US/questions/firefox), [forums.mozillazine.org](http://forums.mozillazine.org/). Files in `lib` are from [MrOtherGuy/firefox-csshacks](https://github.com/MrOtherGuy/firefox-csshacks/).
+Made possible with advice and code examples contributed by the community of [reddit.com/r/FirefoxCSS](https://www.reddit.com/r/FirefoxCSS/), [support.mozilla.org](https://support.mozilla.org/en-US/questions/firefox), [forums.mozillazine.org](http://forums.mozillazine.org/). Files in `lib` are from [MrOtherGuy/firefox-csshacks](https://github.com/MrOtherGuy/firefox-csshacks/). Updated to be compatible with OSx Big Sur 11 and Firefox 88 by [@floriandierickx](https://github.com/floriandierickx/) and [@gamunu](https://github.com/gamunu).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Make Firefox look native on macOS.
 
 Updated package from https://github.com/diedummydie/Safari-Theme-for-Firefox, compatible with OSx Big Sur and Firefox 88. Errors that have been resolved in this first release:
 
+- Fix empty back and forward buttons (fix from @gamunu, https://github.com/diedummydie/Safari-Theme-for-Firefox/pull/19)
 - Location minimize/maximize/close buttons on OSx restored
 - Removed borders, thick lightblue border when activated
 - Resolved issue of moving text while hovering over tabs

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 Make Firefox look more native on macOS.
 
+Updated package from https://github.com/diedummydie/Safari-Theme-for-Firefox, compatible with OSx Big Sur and Firefox 88. Errors that have been resolved in this first release:
+
+- Location minimize/maximize/close buttons on OSx restored
+- Removed borders, thick lightblue border when activated
+- Resolved issue of moving text while hovering over tabs
+- ...
+
+Example of this update:
+
+<img width="462" alt="Screenshot 2021-05-14 at 22 21 13" src="https://user-images.githubusercontent.com/12695083/118324751-f8401780-b4f1-11eb-906f-cc120353ba58.png">
+<img width="478" alt="Screenshot 2021-05-14 at 22 22 05" src="https://user-images.githubusercontent.com/12695083/118324817-13ab2280-b4f2-11eb-8475-87b4317e89b5.png">
+
+
 Switch between Light Mode and Dark Mode without editing CSS.
 
 ![screenshot](https://raw.githubusercontent.com/diedummydie/Safari-Theme-for-Firefox/master/etc/screenshot.jpg)

--- a/lib/hide_tabs_with_one_tab.css
+++ b/lib/hide_tabs_with_one_tab.css
@@ -15,9 +15,7 @@
 #tabbrowser-tabs > .tabbrowser-arrowscrollbox {
   min-height: 0 !important;
 }
-
 :root:not([customizing]) #tabbrowser-tabs .tabs-newtab-button,
-:root:not([customizing]) #tabs-newtab-button,
 :root:not([customizing]) #TabsToolbar .titlebar-button {
   -moz-appearance: none !important;
   height: 0px;
@@ -29,13 +27,9 @@
   max-height: 0px;
   visibility: collapse !important;
 }
+
 #tabbrowser-tabs .tabbrowser-tab {
   height: var(--tab-min-height);
-}
-
-#tabbrowser-tabs
-  .tabbrowser-tab[first-visible-tab="true"][last-visible-tab="true"] {
-  visibility: collapse !important;
 }
 
 /* Button re-styling */

--- a/userChrome.css
+++ b/userChrome.css
@@ -243,7 +243,7 @@ tab:-moz-window-inactive {
 
 .tab-icon-image,
 .tab-throbber {
-  margin: 1px 6px 1px -4px !important;
+  margin: 1px 6px 1px 0px !important;
   transition-duration: 0.1s !important;
 }
 

--- a/userChrome.css
+++ b/userChrome.css
@@ -1,13 +1,15 @@
 /* Safari Theme for Firefox
- * https://github.com/diedummydie/Safari-Theme-for-Firefox
+ * https://github.com/floriandierickx/Safari-Theme-for-Firefox/ forked from https://github.com/diedummydie/Safari-Theme-for-Firefox and adapted to OSx Big Sur and Firefox 88
  */
 
 /* https://github.com/MrOtherGuy/firefox-csshacks */
 @import "lib/Fx65_tabs_on_bottom.css";
 @import "lib/hide_tabs_with_one_tab.css";
 
-.titlebar-buttonbox-container {
-  top: 0 !important;
+.titlebar-buttonbox-container{
+    position:   fixed;
+    top:        10px;
+    left:      0px;
 }
 
 #nav-bar {
@@ -427,21 +429,6 @@ spacer {
   width: calc(100% - 12px) !important;
 }
 
-/* Resolve close min maximum button size. Solution from https://support.mozilla.org/en-US/questions/1222872*/
-
-titlebar-buttonbox {
- display: flex !important;
- flex-direction: row-reverse !important;
-}
-
-.titlebar-placeholder[type="pre-tabs"] {
- width: 100px !important;
-}
-
-/* #titlebar-secondary-buttonbox:-moz-locale-dir(rtl), */
-titlebar-buttonbox-container {
- -moz-box-ordinal-group: 0 !important;
-}
 
 /* Change URLBar Properties */
 

--- a/userChrome.css
+++ b/userChrome.css
@@ -345,3 +345,42 @@ spacer {
  --tab-min-height: 25px !important;
 }
 #TabsToolbar {height: var(--tab-min-height) !important;}
+
+/*** BEGIN Firefox 77 (June 2, 2020) Override URL bar enlargement. Solution from https://support.mozilla.org/en-US/questions/1289355#question-reply ***/
+
+  /* Compute new position, width, and padding */
+
+  #urlbar[breakout][breakout-extend] {
+    top: 5px !important;
+    left: 0px !important;
+    width: 100% !important;
+    padding: 0px !important;
+  }
+  /* for alternate Density settings */
+  [uidensity="compact"] #urlbar[breakout][breakout-extend] {
+    top: 3px !important;
+  }
+  [uidensity="touch"] #urlbar[breakout][breakout-extend] {
+    top: 4px !important;
+  }
+
+  /* Prevent shift of URL bar contents */
+
+  #urlbar[breakout][breakout-extend] > #urlbar-input-container {
+    height: var(--urlbar-height) !important;
+    padding: 0 !important;
+  }
+
+  /* Do not animate */
+
+  #urlbar[breakout][breakout-extend] > #urlbar-background {
+    animation: none !important;;
+  }
+
+  /* Remove shadows */
+
+  #urlbar[breakout][breakout-extend] > #urlbar-background {
+    box-shadow: none !important;
+  }
+
+/*** END Firefox 77 (June 2, 2020) Override URL bar enlargement ***/

--- a/userChrome.css
+++ b/userChrome.css
@@ -1,5 +1,5 @@
 /* Safari Theme for Firefox
- * https://github.com/floriandierickx/Safari-Theme-for-Firefox/ forked from https://github.com/diedummydie/Safari-Theme-for-Firefox and adapted to OSx Big Sur and Firefox 88
+ * https://github.com/diedummydie/Safari-Theme-for-Firefox with contributions of https://github.com/floriandierickx/Safari-Theme-for-Firefox/ for adaptation to OSx Big Sur and Firefox 88
  */
 
 /* https://github.com/MrOtherGuy/firefox-csshacks */
@@ -364,7 +364,7 @@ spacer {
 }
 #TabsToolbar {height: var(--tab-min-height) !important;}
 
-/*** BEGIN Firefox 77 (June 2, 2020) Override URL bar enlargement. Solution from https://support.mozilla.org/en-US/questions/1289355#question-reply ***/
+/*** [OSx Big Sur / Firefox 88 update] BEGIN Firefox 77 (June 2, 2020) Override URL bar enlargement. Solution from https://support.mozilla.org/en-US/questions/1289355#question-reply ***/
 
   /* Compute new position, width, and padding */
 
@@ -405,7 +405,7 @@ spacer {
 
 
 
-/* Force black-on-white for address bar drop-down. Solution from https://support.mozilla.org/en-US/questions/1289990#question-reply*/
+/* [OSx Big Sur / Firefox 88 update] Force black-on-white for address bar drop-down. Solution from https://support.mozilla.org/en-US/questions/1289990#question-reply*/
 .urlbarView {
   /* Eliminate dark background outside */
   margin-left: 0 !important;
@@ -430,8 +430,7 @@ spacer {
 }
 
 
-/* Change URLBar Properties */
-
+/* [OSx Big Sur / Firefox 88 update] Change URLBar Properties */
 
 #urlbar[breakout][breakout-extend] #urlbar-background {
 border-color: #89b3f9 !important;

--- a/userChrome.css
+++ b/userChrome.css
@@ -334,3 +334,14 @@ spacer {
 .tabbrowser-arrowscrollbox {
   margin-right: -1px;
 }
+
+
+/* TABS: height. Solution based on https://support.mozilla.org/nl/questions/1243994 */ 
+:root {
+ --tab-toolbar-navbar-overlap: 0px !important; /* fix for full screen mode */
+ --tab-min-height: 25px !important;
+}
+:root #tabbrowser-tabs {
+ --tab-min-height: 25px !important;
+}
+#TabsToolbar {height: var(--tab-min-height) !important;}

--- a/userChrome.css
+++ b/userChrome.css
@@ -4,7 +4,7 @@
 
 /* https://github.com/MrOtherGuy/firefox-csshacks */
 @import "lib/Fx65_tabs_on_bottom.css";
-@import "lib/hide_tabs_with_one_tab.css"; /* broken */
+@import "lib/hide_tabs_with_one_tab.css";
 
 .titlebar-buttonbox-container {
   top: 0 !important;
@@ -148,11 +148,11 @@ tab:-moz-window-inactive {
 }
 
 #back-button {
-  list-style-image: url("chrome://browser/skin/arrow-left.svg") !important;
+  list-style-image: url("chrome://global/skin/icons/arrow-left.svg") !important;
 }
 
 #forward-button {
-  list-style-image: url("chrome://browser/skin/arrow-left.svg") !important;
+  list-style-image: url("chrome://global/skin/icons/arrow-left.svg") !important;
   transform: scaleX(-1) !important;
   margin-left: 1px !important;
 }
@@ -335,8 +335,23 @@ spacer {
   margin-right: -1px;
 }
 
+/* Remove Page Actions Menu */
+#pageActionButton
+{
+  display: none !important;
+}
+/* Put refresh button "inside" address bar */
+#pageActionSeparator
+{
+    margin-right:26px !important;
+}
 
-/* TABS: height. Solution based on https://support.mozilla.org/nl/questions/1243994 */ 
+/* hide tracking protection container */
+#tracking-protection-icon-container{
+   display: none;
+}
+
+/* TABS: height */
 :root {
  --tab-toolbar-navbar-overlap: 0px !important; /* fix for full screen mode */
  --tab-min-height: 25px !important;
@@ -384,3 +399,50 @@ spacer {
   }
 
 /*** END Firefox 77 (June 2, 2020) Override URL bar enlargement ***/
+
+
+
+/* Force black-on-white for address bar drop-down. Solution from https://support.mozilla.org/en-US/questions/1289990#question-reply*/
+.urlbarView {
+  /* Eliminate dark background outside */
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+  width: 100% !important;
+  /* Preserve bottom border */
+  border-bottom: 1px solid
+    var(--toolbar-field-focus-border-color);
+}
+.urlbarView-body-inner, .search-one-offs {
+  /* Pure black, slightly off-white background */
+  color: #000 !important;
+  background-color: #f8f8f8 !important;
+  /* Remove extra line */
+  border-top-color: transparent !important;
+  /* Adjust distance to edges  */
+  padding: 0 6px !important;
+}
+.urlbarView-body-inner {
+  /* Fix width to avoid rows being too long */
+  width: calc(100% - 12px) !important;
+}
+
+/* Resolve close min maximum button size. Solution from https://support.mozilla.org/en-US/questions/1222872*/
+
+titlebar-buttonbox {
+ display: flex !important;
+ flex-direction: row-reverse !important;
+}
+
+/* .tabbrowser-tab {
+ visibility: hidden;
+} */
+
+
+.titlebar-placeholder[type="pre-tabs"] {
+ width: 100px !important;
+}
+
+/* #titlebar-secondary-buttonbox:-moz-locale-dir(rtl), */
+titlebar-buttonbox-container {
+ -moz-box-ordinal-group: 0 !important;
+}

--- a/userChrome.css
+++ b/userChrome.css
@@ -81,14 +81,14 @@ tab:-moz-window-inactive {
 
 #urlbar {
   background-image: linear-gradient(#ffffff06, #00000000) !important;
-  box-shadow: inset 0 1px 0 ffffff2a !important;
+  box-shadow: inset 0 0px 0 ffffff2a !important;
   min-height: 22px !important;
   height: 24px !important;
   margin-top: 3px !important;
   margin-bottom: 3px !important;
   box-sizing: border-box;
-  border: 1px #3b3b3b44 solid !important;
-  border-bottom: 1px #37373744 solid !important;
+  border: 0px #3b3b3b44 solid !important;
+  border-bottom: 0px #37373744 solid !important;
   top:;
 }
 
@@ -435,6 +435,8 @@ spacer {
 
 #urlbar[breakout][breakout-extend] #urlbar-background {
 border-color: #89b3f9 !important;
+border-width: 3px !important;
+
 }
 
 #urlbar[breakout] {
@@ -447,4 +449,15 @@ border-color: #89b3f9 !important;
 
 #urlbar {
     border: none !important;
+}
+
+#urlbar[breakout] > #urlbar-input-container
+{
+	border: none !important;
+	box-shadow: none !important;
+}
+
+#urlbar-background
+{
+	border-color: var(--lwt-toolbar-field-background-color) !important;
 }

--- a/userChrome.css
+++ b/userChrome.css
@@ -87,6 +87,7 @@ tab:-moz-window-inactive {
   box-sizing: border-box;
   border: 1px #3b3b3b44 solid !important;
   border-bottom: 1px #37373744 solid !important;
+  top:;
 }
 
 #urlbar:-moz-window-inactive {
@@ -433,11 +434,6 @@ titlebar-buttonbox {
  flex-direction: row-reverse !important;
 }
 
-/* .tabbrowser-tab {
- visibility: hidden;
-} */
-
-
 .titlebar-placeholder[type="pre-tabs"] {
  width: 100px !important;
 }
@@ -445,4 +441,23 @@ titlebar-buttonbox {
 /* #titlebar-secondary-buttonbox:-moz-locale-dir(rtl), */
 titlebar-buttonbox-container {
  -moz-box-ordinal-group: 0 !important;
+}
+
+/* Change URLBar Properties */
+
+
+#urlbar[breakout][breakout-extend] #urlbar-background {
+border-color: #89b3f9 !important;
+}
+
+#urlbar[breakout] {
+  display: block;
+  position: absolute;
+  width: 100%;
+  top: 3px !important;
+  left: 0;
+}
+
+#urlbar {
+    border: none !important;
 }


### PR DESCRIPTION
Errors that have been resolved:

- Fix empty back and forward buttons (fix from @gamunu, https://github.com/diedummydie/Safari-Theme-for-Firefox/pull/19)
- Location minimize/maximize/close buttons on OSx restored
- Removed borders, thick lightblue border when activated
- Resolved issue of moving text while hovering over tabs